### PR TITLE
chore: use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,5 +22,3 @@ jobs:
         registry-url: 'https://registry.npmjs.org/'
     - run: npm install
     - run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use trusted publishing following documentation: https://docs.npmjs.com/trusted-publishers