### PR TITLE
Chore: (SCD-552) - use trusted npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Create GitHub Release
       uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # pin@v1.13.0
       with:
-        tag: ${{ github.ref_name }}
+        tag: ${{github.event.release.tag_name}}
     - uses: actions/setup-node@v4
       with:
         node-version: '22.14.0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
         tag: ${{ github.ref_name }}
     - uses: actions/setup-node@v4
       with:
-        node-version: '22'
+        node-version: '22.14.0'
         registry-url: 'https://registry.npmjs.org/'
+    - name: Ensure npm >= 11.5.1
+      run: npm install -g npm@^11.5.1
     - run: npm install
     - run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         tag: ${{ github.ref_name }}
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         registry-url: 'https://registry.npmjs.org/'
     - run: npm install
     - run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Create GitHub Release
       uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # pin@v1.13.0
       with:
-        tag: ${{github.event.release.tag_name}}
+        tag: ${{ github.ref_name }}
     - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         registry-url: 'https://registry.npmjs.org/'
     - run: npm install
-    - run: npm publish --access public
+    - run: npm publish --provenance --access public


### PR DESCRIPTION
Fixes the `phrase-js` release workflow to work with trusted `npm` publishing and restores tag-based publishing.

`phrase-js` releases are triggered by push on tags, but the workflow used `github.event.release.tag_name` for the release tag. That field is not present on push events, which can break release creation and block npm publishing.


Also updated to node LTS version 22, because it is a requirement for OIDC to work:
https://docs.npmjs.com/trusted-publishers

> Note: Trusted publishing requires [npm CLI](https://docs.npmjs.com/cli/v11) version 11.5.1 or later and Node version 22.14.0 or higher.


Ticket:
https://phrase.atlassian.net/browse/SCD-552